### PR TITLE
fix: #11 Checker fails with capital letters in url

### DIFF
--- a/bridges/python/utils.py
+++ b/bridges/python/utils.py
@@ -66,7 +66,7 @@ def output(type, code, speech = ''):
 def finddomains(string):
 	"""Find a domain name substring from a string"""
 
-	return findall('[a-z0-9\-]{,63}\.[a-z0-9\-\.]{2,191}', string)
+	return findall('[a-z0-9\-]{,63}\.[a-z0-9\-\.]{2,191}', string.lower())
 
 def http(method, url):
 	"""Send HTTP request with the Leon user agent"""


### PR DESCRIPTION
<!--

Thanks a lot for your interest in contributing to Leon! :heart:

Please first discuss the change you wish to make via issue,
email, or any other method with the owners of this repository before making a change.
It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon/blob/develop/.github/CONTRIBUTING.md

Please place an x (no spaces - [x]) in all [ ] that apply.

-->

### What type of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?
- [ ] Yes
- [x] No

### List any relevant issue numbers:
#11 Checker fails with capital letters in url 

### Description:

Using regex from finddomains no capital letter are allowed check [here](https://pythex.org/?regex=%5Ba-z0-9%5C-%5D%7B%2C63%7D%5C.%5Ba-z0-9%5C-%5C.%5D%7B2%2C191%7D&test_string=Twitter.com%20est%20down%20%3F%0A&ignorecase=0&multiline=0&dotall=0&verbose=0) 
with a `string.lower()` it's work well