### PR TITLE
Remove `apk update` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ WORKDIR /app
 COPY . .
 
 # Install system packages
-RUN apk update --no-cache \
-  && apk add --no-cache \
+RUN apk add --no-cache \
     ca-certificates \
     build-base \
     python3 \


### PR DESCRIPTION
With `--no-cache` on `apk add`, there is no need to do `apk update`

### What type of change does this PR introduce?
- [x] Refactor

### Does this PR introduce breaking changes?
- [ ] Yes
- [x] No

### Description:

Sorry that I didn't open an issue first as this seems very trivial. If an issue is required, please let me know and I'll open it, thanks!
