### PR TITLE
chore(docker): fix docker in dev env and  fix wrong LEON_PORT

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,3 +12,4 @@ services:
     command: 'npm run dev:server && npm run dev:app'
     volumes:
       - './:/app'
+      - 'node_modules:/app/node_modules'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,8 @@ services:
     image: 'leonai/leon'
     ports:
       - '${LEON_PORT:-1337}:${LEON_PORT:-1337}'
+    environment:
+      LEON_PORT: ${LEON_PORT:-1337}
     stdin_open: true
     tty: true
     command: 'npm run dev:server && npm run dev:app'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     image: 'leonai/leon'
     ports:
       - '${LEON_PORT:-1337}:${LEON_PORT:-1337}'
+    environment:
+      LEON_PORT: ${LEON_PORT:-1337}
     stdin_open: true
     tty: true
     command: 'npm run start'


### PR DESCRIPTION
<!--

Thanks a lot for your interest in contributing to Leon! :heart:

Please first discuss the change you wish to make via issue,
email, or any other method with the owners of this repository before making a change.
It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon/blob/develop/.github/CONTRIBUTING.md

Please place an x (no spaces - [x]) in all [ ] that apply.

-->

### What type of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?
- [ ] Yes
- [x] No

### List any relevant issue numbers:

Close #237 

### Description:

This PR resolve 2 bugs with Docker :
- [x] Fix Docker in development environment by ignoring `node_modules` inside the volume
- [x] Fix wrong `LEON_PORT`, for example something like this : `LEON_PORT=8080 docker-compose up` would not work before, now we can set `LEON_PORT` on the fly, not necessarily only in `.env` file, but it still works, by order of priority, it's first the env variables in the current shell, then the variables inside `.env`.