### PR TITLE
fix(docker): check should not allocate a pseudo-TTY

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "docker:build": "docker build -t leonai/leon .",
     "docker:run": "docker-compose up",
     "docker:dev": "docker-compose --file=docker-compose.dev.yml up",
-    "docker:check": "docker run --rm -it leonai/leon npm run check"
+    "docker:check": "docker run --rm --interactive leonai/leon npm run check"
   },
   "dependencies": {
     "@aws-sdk/client-polly": "^3.18.0",


### PR DESCRIPTION
<!--

Thanks a lot for your interest in contributing to Leon! :heart:

Please first discuss the change you wish to make via issue,
email, or any other method with the owners of this repository before making a change.
It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon/blob/develop/.github/CONTRIBUTING.md

Please place an x (no spaces - [x]) in all [ ] that apply.

-->

### What type of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?
- [ ] Yes
- [x] No

### Description:

This PR fixes a bug where "the input device is not a TTY" using Docker.
We don't need to allocate a pseudo-TTY for running `npm run docker:check`, so we remove it.
We still have the logs thanks to the `-i` or `--interactive` option. :smile:
