### PR TITLE
fix(docker): usage of Ubuntu base image with pyenv and nvm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,2 @@
 node_modules/
 bridges/python/.venv/*
-
-!bridges/python/.venv/.gitkeep

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,68 @@
-FROM node:16-alpine
+FROM ubuntu:latest
 ENV IS_DOCKER true
-WORKDIR /app
 
-# Install system packages
-RUN apk add --no-cache --no-progress \
+# Replace shell with bash so we can source files
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# Set debconf to run non-interactively
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Install base dependencies
+RUN apt-get update && apt-get install --yes -q --no-install-recommends \
+  apt-transport-https \
+  build-essential \
   ca-certificates \
-  py3-pip \
+  curl \
   git \
-  tzdata
+  wget \
+  libssl-dev  \
+  zlib1g-dev  \
+  libbz2-dev  \
+  libreadline-dev  \
+  libsqlite3-dev  \
+  llvm  \
+  libncurses5-dev  \
+  xz-utils  \
+  tk-dev libxml2-dev  \
+  libxmlsec1-dev  \
+  libffi-dev  \
+  liblzma-dev
 
-# Upgrade pip and install Pipenv
-RUN pip3 install --no-cache-dir --progress-bar off pipenv
+# Run the container as an unprivileged user
+RUN groupadd docker && useradd -g docker -s /bin/bash -m docker
+USER docker
+WORKDIR /home/docker
+
+# Install Node.js with nvm
+ENV NVM_DIR /home/docker/nvm
+ENV NODE_VERSION v16.17.0
+
+RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
+RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION"
+
+ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
+ENV PATH      $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
+
+# Install Python with pyenv
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git .pyenv
+ENV PYENV_ROOT="/home/docker/.pyenv"
+ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+
+ENV PYTHON_VERSION=3.9.10
+RUN pyenv install ${PYTHON_VERSION}
+RUN pyenv global ${PYTHON_VERSION}
+
+# Install Pipenv
+ENV PYTHON_BIN_PATH /home/docker/.local/bin
+ENV PATH="${PYTHON_BIN_PATH}:${PATH}"
+RUN python -m pip install --user --force-reinstall pipenv virtualenv
 
 # Install Leon
-COPY ./ ./
+WORKDIR /home/docker/leon
+USER root
+RUN chown -R docker /home/docker/leon
+USER docker
+COPY --chown=docker ./ ./
 RUN npm install
 RUN npm run build
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,17 +1,17 @@
-version: '3.0'
 services:
-  leon-ai:
-    container_name: 'leon-ai'
+  leon:
+    container_name: 'leon'
     build:
       context: './'
-    image: 'leonai/leon'
-    ports:
-      - '${LEON_PORT:-1337}:${LEON_PORT:-1337}'
+    image: 'leon-ai/leon'
     environment:
       LEON_PORT: ${LEON_PORT:-1337}
+      LEON_PY_TCP_SERVER_HOST: ${LEON_PY_TCP_SERVER_HOST:-0.0.0.0}
+      LEON_PY_TCP_SERVER_PORT: ${LEON_PY_TCP_SERVER_PORT:-1342}
     stdin_open: true
     tty: true
     command: 'npm run dev:server && npm run dev:app'
     volumes:
       - './:/app'
       - '/app/node_modules'
+    network_mode: 'host'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
-version: '3.0'
 services:
-  leon-ai:
-    container_name: 'leon-ai'
+  leon:
+    container_name: 'leon'
     build:
       context: './'
-    image: 'leonai/leon'
-    ports:
-      - '${LEON_PORT:-1337}:${LEON_PORT:-1337}'
+    image: 'leon-ai/leon'
     environment:
       LEON_PORT: ${LEON_PORT:-1337}
+      LEON_PY_TCP_SERVER_HOST: ${LEON_PY_TCP_SERVER_HOST:-0.0.0.0}
+      LEON_PY_TCP_SERVER_PORT: ${LEON_PY_TCP_SERVER_PORT:-1342}
     stdin_open: true
     tty: true
     command: 'npm run start'
+    network_mode: 'host'

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
     "train": "babel-node scripts/train/run-train.js",
     "prepare-release": "babel-node scripts/release/prepare-release.js",
     "check": "babel-node scripts/run-check.js",
-    "docker:build": "docker build -t leonai/leon .",
-    "docker:run": "docker-compose up",
-    "docker:dev": "docker-compose --file=docker-compose.dev.yml up",
-    "docker:check": "docker run --rm --interactive leonai/leon npm run check"
+    "docker:build": "docker build -t leon-ai/leon .",
+    "docker:run": "docker compose up",
+    "docker:dev": "docker compose --file=docker-compose.dev.yml up",
+    "docker:check": "docker run --rm --interactive leon-ai/leon npm run check"
   },
   "dependencies": {
     "@aws-sdk/client-polly": "^3.18.0",

--- a/scripts/commit-msg.js
+++ b/scripts/commit-msg.js
@@ -13,7 +13,7 @@ const commitEditMsgFile = '.git/COMMIT_EDITMSG'
 if (fs.existsSync(commitEditMsgFile)) {
   try {
     const commitMessage = fs.readFileSync(commitEditMsgFile, 'utf8')
-    const regex = '(build|BREAKING|chore|ci|docs|feat|fix|perf|refactor|style|test)(\\((web app|server|hotword|skill\\/([\\w-]+)))?\\)?: .{1,50}' // eslint-disable-line no-useless-escape
+    const regex = '(build|BREAKING|chore|ci|docs|feat|fix|perf|refactor|style|test)(\\((web app|docker|server|hotword|skill\\/([\\w-]+)))?\\)?: .{1,50}' // eslint-disable-line no-useless-escape
 
     if (commitMessage.match(regex) !== null) {
       log.success('Commit message validated')

--- a/scripts/setup/setup-python-packages.js
+++ b/scripts/setup/setup-python-packages.js
@@ -56,13 +56,17 @@ export default () => new Promise(async (resolve, reject) => {
         await installPythonPackages()
       } else {
         const dotProjectPath = path.join(process.cwd(), 'bridges/python/.venv/.project')
-        const dotProjectMtime = fs.statSync(dotProjectPath).mtime
+        if (fs.existsSync(dotProjectPath)) {
+          const dotProjectMtime = fs.statSync(dotProjectPath).mtime
 
-        // Check if Python deps tree has been modified since the initial setup
-        if (pipfileLockMtime > dotProjectMtime) {
-          await installPythonPackages()
+          // Check if Python deps tree has been modified since the initial setup
+          if (pipfileLockMtime > dotProjectMtime) {
+            await installPythonPackages()
+          } else {
+            log.success('Python packages are up-to-date')
+          }
         } else {
-          log.success('Python packages are up-to-date')
+          await installPythonPackages()
         }
       }
 


### PR DESCRIPTION
<!--

Thanks a lot for your interest in contributing to Leon! :heart:

Please first discuss the change you wish to make via issue,
email, or any other method with the owners of this repository before making a change.
It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon/blob/develop/.github/CONTRIBUTING.md

Please place an x (no spaces - [x]) in all [ ] that apply.

-->

### What type of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?
- [ ] Yes
- [x] No

### Description:

### The problem

This PR fixes Docker installation by fixing the start of Python TCP server.
The problem with the Docker installation is that we used Alpine Linux and `apk` package manager to install python, using the `apk add py3-pip` command but that installed the latest Python stable version (currently: Python v3.10.6), not what we explicitly wanted/required in `bridges/python/Pipfile`, that means `pipenv` didn't start the TCP server as it didn't have the correct Python version.

### The suggested solution

Instead, to use Linux Alpine, we use the Ubuntu base image, and install Node.js with `nvm` and Python with `pyenv`, as we do in the CLI.
This has the advantage to be closer to the "classical" installation (without docker).

Concerning implementation details, I will comment on lines that probably needs explication. :smile:
