### PR TITLE
Fixed Missing dependencies for TCP Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN pyenv global ${PYTHON_VERSION}
 # Install Pipenv
 ENV PYTHON_BIN_PATH /home/docker/.local/bin
 ENV PATH="${PYTHON_BIN_PATH}:${PATH}"
-RUN python -m pip install --user --force-reinstall pipenv virtualenv
+RUN python -m pip install --user --force-reinstall pipenv virtualenv tinydb requests
 
 # Install Leon
 WORKDIR /home/docker/leon


### PR DESCRIPTION
<!--

Thanks a lot for your interest in contributing to Leon! :heart:

Please first discuss the change you wish to make via issue,
email, or any other method with the owners of this repository before making a change.
It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon/blob/develop/.github/CONTRIBUTING.md

Please place an x (no spaces - [x]) in all [ ] that apply.

-->

### What type of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?
- [ ] Yes
- [x] No

### List any relevant issue numbers:

### Description:
This PR fixes two missing dependencies in the Dockerfile that cause the Python TCP Server not to start.