### PR TITLE
npm --prefix not fit with same directory with leon/package.json on window 10

### DIFF
--- a/scripts/setup/setup-binaries.js
+++ b/scripts/setup/setup-binaries.js
@@ -103,7 +103,7 @@ const setupBinaries = async (key) => {
         LogHelper.info('Installing Node.js bridge npm packages...')
 
         await command(
-          `npm install --package-lock=false --prefix ${NODEJS_BRIDGE_ROOT_PATH}`,
+          `cd ${NODEJS_BRIDGE_ROOT_PATH} && npm install --package-lock=false`,
           {
             shell: true
           }

--- a/scripts/setup/setup-skills/install-nodejs-skills-packages.js
+++ b/scripts/setup/setup-skills/install-nodejs-skills-packages.js
@@ -48,7 +48,7 @@ export default async function (skillFriendlyName, currentSkill) {
         )
 
         await command(
-          `npm install --package-lock=false --prefix ${skillSRCPath}`,
+          `cd ${skillSRCPath} && npm install --package-lock=false`,
           {
             shell: true
           }


### PR DESCRIPTION


<!--

Thanks a lot for your interest in contributing to Leon! :heart:

Please first discuss the change you wish to make via issue,
email, or any other method with the owners of this repository before making a change.
It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon/blob/develop/.github/CONTRIBUTING.md

Please place an x (no spaces - [x]) in all [ ] that apply.

-->

### What type of change does this PR introduce?

- [ x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?

- [ ] Yes
- [x ] No

### List any relevant issue numbers:

### Description:

With this fix, I solved the tcp-server failed to start error that I received while trying to install with leon-cli on Windows. On Windows, the npm --prefix command cannot run an npm install command in the other directory because there is a package.json under the .leon directory.

I solved this by going to the install directory with the 'cd' command.
