### PR TITLE
fix(server): make leon handle multiple socket.io-client instances

### DIFF
--- a/server/src/core/asr/asr.ts
+++ b/server/src/core/asr/asr.ts
@@ -8,6 +8,8 @@ import { TMP_PATH } from '@/constants'
 import { STT } from '@/core'
 import { LogHelper } from '@/helpers/log-helper'
 
+import { ClientSocket } from '../socket-server'
+
 export default class ASR {
   private static instance: ASR
 
@@ -29,7 +31,7 @@ export default class ASR {
    * Encode audio blob to WAVE file
    * and forward the WAVE file to the STT parser
    */
-  public encode(blob: Buffer): Promise<void> {
+  public encode(blob: Buffer, socket: ClientSocket): Promise<void> {
     return new Promise((resolve, reject) => {
       LogHelper.title('ASR')
 
@@ -60,7 +62,7 @@ export default class ASR {
               if (!STT.isParserReady) {
                 reject(new Error('The speech recognition is not ready yet'))
               } else {
-                STT.transcribe(this.audioPaths.wav)
+                STT.transcribe(this.audioPaths.wav, socket)
                 resolve()
               }
             })

--- a/server/src/core/http-server/api/utterance/post.ts
+++ b/server/src/core/http-server/api/utterance/post.ts
@@ -2,7 +2,7 @@ import type { FastifyPluginAsync, FastifySchema } from 'fastify'
 import { Type } from '@sinclair/typebox'
 import type { Static } from '@sinclair/typebox'
 
-import { NLU, BRAIN } from '@/core'
+import { NLU } from '@/core'
 import type { APIOptions } from '@/core/http-server/http-server'
 
 const postUtteranceSchema = {
@@ -29,7 +29,6 @@ export const postUtterance: FastifyPluginAsync<APIOptions> = async (
       const { utterance } = request.body
 
       try {
-        BRAIN.isMuted = true
         const data = await NLU.process(utterance)
 
         reply.send({

--- a/server/src/core/index.ts
+++ b/server/src/core/index.ts
@@ -3,7 +3,6 @@ import TCPClient from '@/core/tcp-client'
 import HTTPServer from '@/core/http-server/http-server'
 import SocketServer from '@/core/socket-server'
 import SpeechToText from '@/core/stt/stt'
-import TextToSpeech from '@/core/tts/tts'
 import AutomaticSpeechRecognition from '@/core/asr/asr'
 import NamedEntityRecognition from '@/core/nlp/nlu/ner'
 import ModelLoader from '@/core/nlp/nlu/model-loader'
@@ -25,14 +24,12 @@ export const SOCKET_SERVER = new SocketServer()
 
 export const STT = new SpeechToText()
 
-export const TTS = new TextToSpeech()
-
 export const ASR = new AutomaticSpeechRecognition()
 
 export const NER = new NamedEntityRecognition()
 
 export const MODEL_LOADER = new ModelLoader()
 
-export const NLU = new NaturalLanguageUnderstanding()
-
+// TODO: THIS IS USED OVER HTTP (FOR HTTP REQUESTS)
 export const BRAIN = new Brain()
+export const NLU = new NaturalLanguageUnderstanding(BRAIN)

--- a/server/src/core/socket-server.ts
+++ b/server/src/core/socket-server.ts
@@ -2,19 +2,13 @@ import type { DefaultEventsMap } from 'socket.io/dist/typed-events'
 import { Server as SocketIOServer, Socket } from 'socket.io'
 
 import { LANG, HAS_STT, HAS_TTS, IS_DEVELOPMENT_ENV } from '@/constants'
-import {
-  HTTP_SERVER,
-  TCP_CLIENT,
-  ASR,
-  STT,
-  TTS,
-  NLU,
-  BRAIN,
-  MODEL_LOADER
-} from '@/core'
+import { HTTP_SERVER, TCP_CLIENT, ASR, STT, MODEL_LOADER } from '@/core'
 import { LogHelper } from '@/helpers/log-helper'
 import { LangHelper } from '@/helpers/lang-helper'
 import { Telemetry } from '@/telemetry'
+import TextToSpeech from '@/core/tts/tts'
+import NaturalLanguageUnderstanding from '@/core/nlp/nlu/nlu'
+import Brain from '@/core/brain/brain'
 
 interface HotwordDataEvent {
   hotword: string
@@ -26,19 +20,47 @@ interface UtteranceDataEvent {
   value: string
 }
 
-export default class SocketServer {
-  private static instance: SocketServer
+export type ClientSocket = Socket<DefaultEventsMap, DefaultEventsMap>
 
-  public socket: Socket<DefaultEventsMap, DefaultEventsMap> | undefined =
-    undefined
+export default class SocketServer {
+  private nlus: Map<string, NaturalLanguageUnderstanding> = new Map()
+  private onConnectionReady!: (socket: ClientSocket) => void
+  private onDisconnect!: (socket: ClientSocket) => void
 
   constructor() {
-    if (!SocketServer.instance) {
-      LogHelper.title('Socket Server')
-      LogHelper.success('New instance')
+    LogHelper.title('Socket Server')
+    LogHelper.success('New instance')
+    ;(this.onConnectionReady = (socket): void => {
+      const brain = new Brain(socket)
+      const nlu = new NaturalLanguageUnderstanding(brain)
+      let ttsState = 'disabled'
+      this.nlus.set(socket.id, nlu)
+      if (HAS_TTS) {
+        this.getSocketTextToSpeech(socket.id)
+          ?.init(LangHelper.getShortCode(LANG))
+          ?.then(() => {
+            ttsState = 'enabled'
+            LogHelper.success(`TTS ${ttsState} for client ${socket.id}`)
+          })
+      }
+    }),
+      (this.onDisconnect = (socket): void => {
+        const { id } = socket
+        this.nlus.get(id)?.brain.dispose()
+        this.nlus.delete(id)
+      })
+  }
 
-      SocketServer.instance = this
-    }
+  private getSocketNlu(
+    socketId: string
+  ): NaturalLanguageUnderstanding | undefined {
+    return this.nlus.get(socketId)
+  }
+  private getSocketBrain(socketId: string): Brain | undefined {
+    return this.getSocketNlu(socketId)?.brain
+  }
+  private getSocketTextToSpeech(socketId: string): TextToSpeech | undefined {
+    return this.getSocketBrain(socketId)?.tts
   }
 
   public async init(): Promise<void> {
@@ -49,22 +71,15 @@ export default class SocketServer {
       : new SocketIOServer(HTTP_SERVER.httpServer)
 
     let sttState = 'disabled'
-    let ttsState = 'disabled'
 
     if (HAS_STT) {
       sttState = 'enabled'
 
       await STT.init()
     }
-    if (HAS_TTS) {
-      ttsState = 'enabled'
-
-      await TTS.init(LangHelper.getShortCode(LANG))
-    }
 
     LogHelper.title('Initialization')
     LogHelper.success(`STT ${sttState}`)
-    LogHelper.success(`TTS ${ttsState}`)
 
     try {
       await MODEL_LOADER.loadNLPModels()
@@ -76,47 +91,45 @@ export default class SocketServer {
       LogHelper.title('Client')
       LogHelper.success('Connected')
 
-      this.socket = socket
-
       // Init
-      this.socket.on('init', (data: string) => {
+      socket.on('init', (data: string) => {
         LogHelper.info(`Type: ${data}`)
-        LogHelper.info(`Socket ID: ${this.socket?.id}`)
+        LogHelper.info(`Socket ID: ${socket.id}`)
 
-        // TODO
-        // const provider = await addProvider(socket.id)
+        this.onConnectionReady(socket)
 
         // Check whether the TCP client is connected to the TCP server
         if (TCP_CLIENT.isConnected) {
-          this.socket?.emit('ready')
+          socket.emit('ready')
         } else {
           TCP_CLIENT.ee.on('connected', () => {
-            this.socket?.emit('ready')
+            socket.emit('ready')
           })
         }
 
         if (data === 'hotword-node') {
           // Hotword triggered
-          this.socket?.on('hotword-detected', (data: HotwordDataEvent) => {
+          socket.on('hotword-detected', (data: HotwordDataEvent) => {
             LogHelper.title('Socket')
             LogHelper.success(`Hotword ${data.hotword} detected`)
 
-            this.socket?.broadcast.emit('enable-record')
+            socket.broadcast.emit('enable-record')
           })
         } else {
           // Listen for new utterance
-          this.socket?.on('utterance', async (data: UtteranceDataEvent) => {
+          socket.on('utterance', async (data: UtteranceDataEvent) => {
             LogHelper.title('Socket')
             LogHelper.info(`${data.client} emitted: ${data.value}`)
 
-            this.socket?.emit('is-typing', true)
+            socket.emit('is-typing', true)
 
             const { value: utterance } = data
             try {
               LogHelper.time('Utterance processed in')
 
-              BRAIN.isMuted = false
-              const processedData = await NLU.process(utterance)
+              const processedData = await this.getSocketNlu(socket.id)?.process(
+                utterance
+              )
 
               if (processedData) {
                 Telemetry.utterance(processedData)
@@ -130,9 +143,9 @@ export default class SocketServer {
           })
 
           // Handle automatic speech recognition
-          this.socket?.on('recognize', async (data: Buffer) => {
+          socket.on('recognize', async (data: Buffer) => {
             try {
-              await ASR.encode(data)
+              await ASR.encode(data, socket)
             } catch (e) {
               LogHelper.error(
                 `ASR - Failed to encode audio blob to WAVE file: ${e}`
@@ -142,9 +155,8 @@ export default class SocketServer {
         }
       })
 
-      this.socket.once('disconnect', () => {
-        // TODO
-        // deleteProvider(this.socket.id)
+      socket.once('disconnect', () => {
+        this.onDisconnect(socket)
       })
     })
   }

--- a/server/src/core/tts/synthesizers/amazon-polly-synthesizer.ts
+++ b/server/src/core/tts/synthesizers/amazon-polly-synthesizer.ts
@@ -8,7 +8,7 @@ import type { LongLanguageCode } from '@/types'
 import type { SynthesizeResult } from '@/core/tts/types'
 import type { AmazonVoiceConfigurationSchema } from '@/schemas/voice-config-schemas'
 import { LANG, VOICE_CONFIG_PATH, TMP_PATH } from '@/constants'
-import { TTS } from '@/core'
+import TextToSpeech from '@/core/tts/tts'
 import { TTSSynthesizerBase } from '@/core/tts/tts-synthesizer-base'
 import { LogHelper } from '@/helpers/log-helper'
 import { StringHelper } from '@/helpers/string-helper'
@@ -27,7 +27,11 @@ export default class AmazonPollySynthesizer extends TTSSynthesizerBase {
   protected readonly lang = LANG as LongLanguageCode
   private readonly client: Polly | undefined = undefined
 
-  constructor(lang: LongLanguageCode) {
+  private _tts: TextToSpeech
+  public get tts(): TextToSpeech {
+    return this._tts
+  }
+  constructor(tts: TextToSpeech, lang: LongLanguageCode) {
     super()
 
     LogHelper.title(this.name)
@@ -36,6 +40,8 @@ export default class AmazonPollySynthesizer extends TTSSynthesizerBase {
     const config: AmazonVoiceConfigurationSchema = JSON.parse(
       fs.readFileSync(path.join(VOICE_CONFIG_PATH, 'amazon.json'), 'utf8')
     )
+
+    this._tts = tts
 
     try {
       this.lang = lang
@@ -81,7 +87,7 @@ export default class AmazonPollySynthesizer extends TTSSynthesizerBase {
 
         const duration = await this.getAudioDuration(audioFilePath)
 
-        TTS.em.emit('saved', duration)
+        this.tts.em.emit('saved', duration)
 
         return {
           audioFilePath,

--- a/server/src/core/tts/synthesizers/flite-synthesizer.ts
+++ b/server/src/core/tts/synthesizers/flite-synthesizer.ts
@@ -5,7 +5,7 @@ import { spawn } from 'node:child_process'
 import type { LongLanguageCode } from '@/types'
 import type { SynthesizeResult } from '@/core/tts/types'
 import { LANG, TMP_PATH, BIN_PATH } from '@/constants'
-import { TTS } from '@/core'
+import TextToSpeech from '@/core/tts/tts'
 import { TTSSynthesizerBase } from '@/core/tts/tts-synthesizer-base'
 import { LogHelper } from '@/helpers/log-helper'
 import { StringHelper } from '@/helpers/string-helper'
@@ -22,7 +22,11 @@ export default class FliteSynthesizer extends TTSSynthesizerBase {
   protected readonly lang = LANG as LongLanguageCode
   private readonly binPath = path.join(BIN_PATH, 'flite', 'flite')
 
-  constructor(lang: LongLanguageCode) {
+  private _tts: TextToSpeech
+  public get tts(): TextToSpeech {
+    return this._tts
+  }
+  constructor(tts: TextToSpeech, lang: LongLanguageCode) {
     super()
 
     LogHelper.title(this.name)
@@ -35,6 +39,8 @@ export default class FliteSynthesizer extends TTSSynthesizerBase {
         'The Flite synthesizer only accepts the "en-US" language at the moment'
       )
     }
+
+    this._tts = tts
 
     if (!fs.existsSync(this.binPath)) {
       LogHelper.error(
@@ -71,7 +77,7 @@ export default class FliteSynthesizer extends TTSSynthesizerBase {
 
     const duration = await this.getAudioDuration(audioFilePath)
 
-    TTS.em.emit('saved', duration)
+    this.tts.em.emit('saved', duration)
 
     return {
       audioFilePath,

--- a/server/src/core/tts/synthesizers/google-cloud-tts-synthesizer.ts
+++ b/server/src/core/tts/synthesizers/google-cloud-tts-synthesizer.ts
@@ -2,13 +2,13 @@ import path from 'node:path'
 import fs from 'node:fs'
 
 import type { TextToSpeechClient } from '@google-cloud/text-to-speech'
-import tts from '@google-cloud/text-to-speech'
+import gTTS from '@google-cloud/text-to-speech'
 import { google } from '@google-cloud/text-to-speech/build/protos/protos'
 
 import type { LongLanguageCode } from '@/types'
+import TextToSpeech from '@/core/tts/tts'
 import type { SynthesizeResult } from '@/core/tts/types'
 import { LANG, VOICE_CONFIG_PATH, TMP_PATH } from '@/constants'
-import { TTS } from '@/core'
 import { TTSSynthesizerBase } from '@/core/tts/tts-synthesizer-base'
 import { LogHelper } from '@/helpers/log-helper'
 import { StringHelper } from '@/helpers/string-helper'
@@ -34,7 +34,11 @@ export default class GoogleCloudTTSSynthesizer extends TTSSynthesizerBase {
   protected readonly lang = LANG as LongLanguageCode
   private readonly client: TextToSpeechClient | undefined = undefined
 
-  constructor(lang: LongLanguageCode) {
+  private _tts: TextToSpeech
+  public get tts(): TextToSpeech {
+    return this._tts
+  }
+  constructor(tts: TextToSpeech, lang: LongLanguageCode) {
     super()
 
     LogHelper.title(this.name)
@@ -45,9 +49,11 @@ export default class GoogleCloudTTSSynthesizer extends TTSSynthesizerBase {
       'google-cloud.json'
     )
 
+    this._tts = tts
+
     try {
       this.lang = lang
-      this.client = new tts.TextToSpeechClient()
+      this.client = new gTTS.TextToSpeechClient()
 
       LogHelper.success('Synthesizer initialized')
     } catch (e) {
@@ -81,7 +87,7 @@ export default class GoogleCloudTTSSynthesizer extends TTSSynthesizerBase {
 
         const duration = await this.getAudioDuration(audioFilePath)
 
-        TTS.em.emit('saved', duration)
+        this.tts.em.emit('saved', duration)
 
         return {
           audioFilePath,

--- a/server/src/core/tts/synthesizers/watson-tts-synthesizer.ts
+++ b/server/src/core/tts/synthesizers/watson-tts-synthesizer.ts
@@ -8,7 +8,7 @@ import type { WatsonVoiceConfigurationSchema } from '@/schemas/voice-config-sche
 import type { LongLanguageCode } from '@/types'
 import type { SynthesizeResult } from '@/core/tts/types'
 import { LANG, VOICE_CONFIG_PATH, TMP_PATH } from '@/constants'
-import { TTS } from '@/core'
+import TextToSpeech from '@/core/tts/tts'
 import { TTSSynthesizerBase } from '@/core/tts/tts-synthesizer-base'
 import { LogHelper } from '@/helpers/log-helper'
 import { StringHelper } from '@/helpers/string-helper'
@@ -27,7 +27,11 @@ export default class WatsonTTSSynthesizer extends TTSSynthesizerBase {
   protected readonly lang: LongLanguageCode = LANG as LongLanguageCode
   private readonly client: Tts | undefined = undefined
 
-  constructor(lang: LongLanguageCode) {
+  private _tts: TextToSpeech
+  public get tts(): TextToSpeech {
+    return this._tts
+  }
+  constructor(tts: TextToSpeech, lang: LongLanguageCode) {
     super()
 
     LogHelper.title(this.name)
@@ -37,6 +41,7 @@ export default class WatsonTTSSynthesizer extends TTSSynthesizerBase {
       fs.readFileSync(path.join(VOICE_CONFIG_PATH, 'watson-stt.json'), 'utf8')
     )
 
+    this._tts = tts
     try {
       this.lang = lang
       this.client = new Tts({
@@ -75,7 +80,7 @@ export default class WatsonTTSSynthesizer extends TTSSynthesizerBase {
 
         const duration = await this.getAudioDuration(audioFilePath)
 
-        TTS.em.emit('saved', duration)
+        this.tts.em.emit('saved', duration)
 
         return {
           audioFilePath,

--- a/server/src/core/tts/tts.ts
+++ b/server/src/core/tts/tts.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 
 import type { ShortLanguageCode } from '@/types'
 import type { TTSSynthesizer } from '@/core/tts/types'
-import { SOCKET_SERVER } from '@/core'
+import Brain from '@/core/brain/brain'
 import { TTS_PROVIDER, VOICE_CONFIG_PATH } from '@/constants'
 import { TTSSynthesizers, TTSProviders } from '@/core/tts/types'
 import { LogHelper } from '@/helpers/log-helper'
@@ -31,13 +31,18 @@ export default class TTS {
   public lang: ShortLanguageCode = 'en'
   public em = new events.EventEmitter()
 
-  constructor() {
+  private _brain: Brain
+  public get brain(): Brain {
+    return this._brain
+  }
+  constructor(brain: Brain) {
     if (!TTS.instance) {
       LogHelper.title('TTS')
       LogHelper.success('New instance')
 
       TTS.instance = this
     }
+    this._brain = brain
   }
 
   /**
@@ -112,7 +117,7 @@ export default class TTS {
         const { audioFilePath, duration } = result
         const bitmap = await fs.promises.readFile(audioFilePath)
 
-        SOCKET_SERVER.socket?.emit(
+        this.brain.socket?.emit(
           'audio-forwarded',
           {
             buffer: Buffer.from(bitmap),


### PR DESCRIPTION
### What type of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?

- [ ] Yes
- [x] No

### List any relevant issue numbers:

### Description:
Make leon handle multiple instances of socket.io-client, you can now open multiple browser window (e.g http://localhost:1337/ ) and each one will start receiving events after an interaction (instead of just one window).
