### PR TITLE
feat: add CAMB AI audio toolkit and core TTS provider

### DIFF
--- a/bridges/python/src/sdk/tools/camb_ai_audio/__init__.py
+++ b/bridges/python/src/sdk/tools/camb_ai_audio/__init__.py
@@ -1,0 +1,3 @@
+from .camb_ai_audio_tool import CambAIAudioTool
+
+__all__ = ["CambAIAudioTool"]

--- a/bridges/python/src/sdk/tools/camb_ai_audio/camb_ai_audio_tool.py
+++ b/bridges/python/src/sdk/tools/camb_ai_audio/camb_ai_audio_tool.py
@@ -1,0 +1,626 @@
+import json
+import time
+from typing import List, Dict, Any, Optional
+
+from ...base_tool import BaseTool
+from ...toolkit_config import ToolkitConfig
+from ...network import Network
+from ..transcription_schema import TranscriptionOutput, TranscriptionSegment
+
+# Hardcoded default settings for CAMB AI audio tool
+CAMB_AI_API_KEY = None
+CAMB_AI_TTS_MODEL = "mars-flash"
+CAMB_AI_DEFAULT_VOICE_ID = None
+DEFAULT_SETTINGS = {
+    "CAMB_AI_API_KEY": CAMB_AI_API_KEY,
+    "CAMB_AI_TTS_MODEL": CAMB_AI_TTS_MODEL,
+    "CAMB_AI_DEFAULT_VOICE_ID": CAMB_AI_DEFAULT_VOICE_ID,
+}
+REQUIRED_SETTINGS = ["CAMB_AI_API_KEY"]
+
+
+class CambAIAudioTool(BaseTool):
+    TOOLKIT = "music_audio"
+
+    def __init__(self):
+        super().__init__()
+        self.config = ToolkitConfig.load(self.TOOLKIT, self.tool_name)
+
+        tool_settings = ToolkitConfig.load_tool_settings(
+            self.TOOLKIT, self.tool_name, DEFAULT_SETTINGS
+        )
+        self.settings = tool_settings
+        self.required_settings = REQUIRED_SETTINGS
+        self._check_required_settings(self.tool_name)
+
+        # Priority: toolkit settings > hardcoded default
+        self.api_key = self.settings.get("CAMB_AI_API_KEY", CAMB_AI_API_KEY)
+        self.tts_model = self.settings.get("CAMB_AI_TTS_MODEL", CAMB_AI_TTS_MODEL)
+        self.default_voice_id = self.settings.get(
+            "CAMB_AI_DEFAULT_VOICE_ID", CAMB_AI_DEFAULT_VOICE_ID
+        )
+
+        self.network = Network({"base_url": "https://client.camb.ai/apis"})
+
+    @property
+    def tool_name(self) -> str:
+        return "camb_ai_audio"
+
+    @property
+    def toolkit(self) -> str:
+        return self.TOOLKIT
+
+    @property
+    def description(self) -> str:
+        return self.config["description"]
+
+    def _get_headers(self, api_key: Optional[str] = None) -> Dict[str, str]:
+        key = api_key or self.api_key
+        if not key:
+            raise Exception("CAMB AI API key is missing")
+        return {"x-api-key": key}
+
+    def _poll_task(
+        self,
+        status_endpoint: str,
+        task_id: str,
+        api_key: Optional[str] = None,
+        timeout: int = 300,
+        poll_interval: int = 5,
+    ) -> Dict[str, Any]:
+        """
+        Poll an async task until completion.
+
+        Args:
+            status_endpoint: The endpoint path for status checks (e.g., '/transcribe')
+            task_id: The task ID to poll
+            api_key: Optional API key override
+            timeout: Max seconds to wait
+            poll_interval: Seconds between polls
+
+        Returns:
+            The final status response data
+        """
+        headers = self._get_headers(api_key)
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            response = self.network.request(
+                {
+                    "url": f"{status_endpoint}/{task_id}",
+                    "method": "GET",
+                    "headers": headers,
+                }
+            )
+            data = response["data"]
+            status = data.get("status", "")
+
+            if status == "SUCCESS":
+                return data
+            elif status in ("FAILED", "ERROR"):
+                raise Exception(
+                    f"CAMB AI task failed: {data.get('error', 'Unknown error')}"
+                )
+
+            time.sleep(poll_interval)
+
+        raise Exception(f"CAMB AI task timed out after {timeout}s")
+
+    def text_to_speech(
+        self,
+        text: str,
+        output_path: str,
+        language: int,
+        voice_id: Optional[int] = None,
+        api_key: Optional[str] = None,
+        speech_model: Optional[str] = None,
+    ) -> str:
+        """
+        Convert text to speech using CAMB AI's streaming TTS API.
+
+        Args:
+            text: The text to convert to speech
+            output_path: Path to save the generated audio file
+            language: CAMB AI language ID
+            voice_id: Voice ID to use (uses default if not provided)
+            api_key: Optional API key override
+            speech_model: TTS model to use (defaults to tool default)
+
+        Returns:
+            The path to the saved audio file
+        """
+        headers = self._get_headers(api_key)
+        voice_id = voice_id or self.default_voice_id
+        speech_model = speech_model or self.tts_model
+
+        payload: Dict[str, Any] = {
+            "text": text,
+            "language": language,
+        }
+        if voice_id is not None:
+            payload["voice_id"] = voice_id
+        if speech_model:
+            payload["speech_model"] = speech_model
+
+        try:
+            response = self.network.request(
+                {
+                    "url": "/tts-stream",
+                    "method": "POST",
+                    "headers": {**headers, "content-type": "application/json"},
+                    "data": payload,
+                    "response_type": "bytes",
+                }
+            )
+
+            with open(output_path, "wb") as f:
+                f.write(response["data"])
+
+            return output_path
+        except Exception as e:
+            raise Exception(f"CAMB AI TTS failed: {str(e)}")
+
+    def translate(
+        self,
+        text: str,
+        source_language: int,
+        target_language: int,
+        api_key: Optional[str] = None,
+    ) -> str:
+        """
+        Translate text using CAMB AI's translation stream API.
+
+        Args:
+            text: The text to translate
+            source_language: CAMB AI source language ID
+            target_language: CAMB AI target language ID
+            api_key: Optional API key override
+
+        Returns:
+            The translated text
+        """
+        headers = self._get_headers(api_key)
+
+        try:
+            response = self.network.request(
+                {
+                    "url": "/translation/stream",
+                    "method": "POST",
+                    "headers": {**headers, "content-type": "application/json"},
+                    "data": {
+                        "source_language": source_language,
+                        "target_language": target_language,
+                        "text": text,
+                    },
+                }
+            )
+
+            data = response["data"]
+            # The translation stream endpoint may return the translated text
+            # in different formats depending on the response
+            if isinstance(data, dict):
+                return data.get("translation", data.get("text", str(data)))
+            return str(data)
+        except Exception as e:
+            raise Exception(f"CAMB AI translation failed: {str(e)}")
+
+    def transcribe_to_file(
+        self,
+        input_path: str,
+        output_path: str,
+        language: int,
+        api_key: Optional[str] = None,
+    ) -> str:
+        """
+        Transcribe audio to a file using CAMB AI's transcription API.
+
+        Args:
+            input_path: Path to the audio file to transcribe
+            output_path: Path to save the JSON transcription (unified format)
+            language: CAMB AI language ID
+            api_key: Optional API key override
+
+        Returns:
+            The path to the transcription file
+        """
+        headers = self._get_headers(api_key)
+
+        try:
+            # Submit transcription task
+            files: dict = {"media_file": open(input_path, "rb")}
+            data: dict = {"language": str(language)}
+
+            response = self.network.request(
+                {
+                    "url": "/transcribe",
+                    "method": "POST",
+                    "headers": headers,
+                    "data": data,
+                    "files": files,
+                    "use_json": False,
+                }
+            )
+
+            task_id = response["data"].get("task_id")
+            if not task_id:
+                raise Exception("No task_id returned from transcription request")
+
+            # Poll for completion
+            result = self._poll_task("/transcribe", task_id, api_key)
+
+            run_id = result.get("run_id")
+            if not run_id:
+                raise Exception("No run_id returned from completed transcription task")
+
+            # Get the transcription result
+            result_response = self.network.request(
+                {
+                    "url": f"/transcription-result/{run_id}",
+                    "method": "GET",
+                    "headers": headers,
+                }
+            )
+
+            parsed_output = self._parse_transcription(result_response["data"])
+
+            with open(output_path, "w", encoding="utf-8") as f:
+                json.dump(parsed_output, f, indent=2, ensure_ascii=False)
+
+            return output_path
+        except Exception as e:
+            raise Exception(f"CAMB AI transcription failed: {str(e)}")
+
+    def _parse_transcription(self, raw_output: Dict[str, Any]) -> TranscriptionOutput:
+        """
+        Parse CAMB AI transcription response into unified schema format.
+
+        Args:
+            raw_output: Raw response from CAMB AI API
+
+        Returns:
+            Parsed transcription in unified format
+        """
+        segments_data = raw_output.get("segments", [])
+        duration = float(raw_output.get("duration", 0))
+
+        unique_speakers: List[str] = []
+        segments: List[TranscriptionSegment] = []
+
+        for seg in segments_data:
+            speaker = seg.get("speaker")
+            if speaker and speaker not in unique_speakers:
+                unique_speakers.append(speaker)
+
+            segments.append(
+                {
+                    "from": float(seg.get("start", 0)),
+                    "to": float(seg.get("end", 0)),
+                    "text": seg.get("text", ""),
+                    "speaker": speaker,
+                }
+            )
+
+        # If no segments but we have a text field, create a single segment
+        if not segments and raw_output.get("text"):
+            segments.append(
+                {
+                    "from": 0.0,
+                    "to": duration,
+                    "text": raw_output["text"],
+                    "speaker": None,
+                }
+            )
+
+        return {
+            "duration": duration,
+            "speakers": unique_speakers,
+            "speaker_count": len(unique_speakers),
+            "segments": segments,
+            "metadata": {"tool": self.tool_name},
+        }
+
+    def translated_tts(
+        self,
+        text: str,
+        voice_id: int,
+        source_language: int,
+        target_language: int,
+        api_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Translate text and generate speech in the target language.
+
+        Args:
+            text: The text to translate and speak
+            voice_id: Voice ID for the output speech
+            source_language: CAMB AI source language ID
+            target_language: CAMB AI target language ID
+            api_key: Optional API key override
+
+        Returns:
+            Task result containing run_id and status
+        """
+        headers = self._get_headers(api_key)
+
+        try:
+            response = self.network.request(
+                {
+                    "url": "/translated-tts",
+                    "method": "POST",
+                    "headers": {**headers, "content-type": "application/json"},
+                    "data": {
+                        "text": text,
+                        "voice_id": voice_id,
+                        "source_language": source_language,
+                        "target_language": target_language,
+                    },
+                }
+            )
+
+            data = response["data"]
+            task_id = data.get("task_id")
+
+            if task_id:
+                result = self._poll_task("/translated-tts", task_id, api_key)
+                run_id = result.get("run_id")
+
+                if run_id:
+                    # Fetch the generated audio from the TTS result endpoint
+                    audio_response = self.network.request(
+                        {
+                            "url": f"/tts-result/{run_id}",
+                            "method": "GET",
+                            "headers": headers,
+                            "response_type": "bytes",
+                        }
+                    )
+                    return {
+                        "run_id": run_id,
+                        "audio_data": audio_response["data"],
+                    }
+
+                return result
+
+            return data
+        except Exception as e:
+            raise Exception(f"CAMB AI translated TTS failed: {str(e)}")
+
+    def clone_voice(
+        self,
+        input_path: str,
+        voice_name: str,
+        gender: int,
+        api_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Clone a voice from an audio sample.
+
+        Args:
+            input_path: Path to the audio sample for voice cloning
+            voice_name: Name for the cloned voice
+            gender: Gender of the voice (1=male, 2=female)
+            api_key: Optional API key override
+
+        Returns:
+            The created voice data including voice ID
+        """
+        headers = self._get_headers(api_key)
+
+        try:
+            files: dict = {"file": open(input_path, "rb")}
+            data: dict = {
+                "voice_name": voice_name,
+                "gender": str(gender),
+            }
+
+            response = self.network.request(
+                {
+                    "url": "/create-custom-voice",
+                    "method": "POST",
+                    "headers": headers,
+                    "data": data,
+                    "files": files,
+                    "use_json": False,
+                }
+            )
+
+            return response["data"]
+        except Exception as e:
+            raise Exception(f"CAMB AI voice cloning failed: {str(e)}")
+
+    def list_voices(
+        self,
+        api_key: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        List all available voices.
+
+        Args:
+            api_key: Optional API key override
+
+        Returns:
+            List of available voices
+        """
+        headers = self._get_headers(api_key)
+
+        try:
+            response = self.network.request(
+                {
+                    "url": "/list-voices",
+                    "method": "GET",
+                    "headers": headers,
+                }
+            )
+
+            return response["data"]
+        except Exception as e:
+            raise Exception(f"CAMB AI list voices failed: {str(e)}")
+
+    def dub_media(
+        self,
+        video_url: str,
+        source_language: int,
+        target_language: int,
+        api_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Dub a video or audio file into a target language.
+
+        Args:
+            video_url: URL of the video/audio to dub
+            source_language: CAMB AI source language ID
+            target_language: CAMB AI target language ID
+            api_key: Optional API key override
+
+        Returns:
+            The dubbing result data
+        """
+        headers = self._get_headers(api_key)
+
+        try:
+            response = self.network.request(
+                {
+                    "url": "/dub",
+                    "method": "POST",
+                    "headers": {**headers, "content-type": "application/json"},
+                    "data": {
+                        "video_url": video_url,
+                        "source_language": source_language,
+                        "target_language": target_language,
+                    },
+                }
+            )
+
+            data = response["data"]
+            task_id = data.get("task_id")
+
+            if task_id:
+                result = self._poll_task("/dub", task_id, api_key)
+                run_id = result.get("run_id")
+
+                if run_id:
+                    # Get the dubbing result
+                    result_response = self.network.request(
+                        {
+                            "url": f"/dub-result/{run_id}",
+                            "method": "GET",
+                            "headers": headers,
+                        }
+                    )
+                    return result_response["data"]
+
+                return result
+
+            return data
+        except Exception as e:
+            raise Exception(f"CAMB AI dubbing failed: {str(e)}")
+
+    def text_to_sound(
+        self,
+        prompt: str,
+        duration: Optional[float] = None,
+        api_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Generate music or sound effects from a text prompt.
+
+        Args:
+            prompt: Text description of the sound to generate
+            duration: Desired duration of the audio in seconds
+            api_key: Optional API key override
+
+        Returns:
+            The text-to-sound result data
+        """
+        headers = self._get_headers(api_key)
+
+        payload: Dict[str, Any] = {"prompt": prompt}
+        if duration is not None:
+            payload["duration"] = duration
+
+        try:
+            response = self.network.request(
+                {
+                    "url": "/text-to-sound",
+                    "method": "POST",
+                    "headers": {**headers, "content-type": "application/json"},
+                    "data": payload,
+                }
+            )
+
+            data = response["data"]
+            task_id = data.get("task_id")
+
+            if task_id:
+                result = self._poll_task("/text-to-sound", task_id, api_key)
+                run_id = result.get("run_id")
+
+                if run_id:
+                    result_response = self.network.request(
+                        {
+                            "url": f"/text-to-sound-result/{run_id}",
+                            "method": "GET",
+                            "headers": headers,
+                            "response_type": "bytes",
+                        }
+                    )
+                    return {"run_id": run_id, "audio_data": result_response["data"]}
+
+                return result
+
+            return data
+        except Exception as e:
+            raise Exception(f"CAMB AI text-to-sound failed: {str(e)}")
+
+    def separate_audio(
+        self,
+        input_path: str,
+        api_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Separate vocals from instrumental audio.
+
+        Args:
+            input_path: Path to the audio file to separate
+            api_key: Optional API key override
+
+        Returns:
+            The audio separation result data
+        """
+        headers = self._get_headers(api_key)
+
+        try:
+            files: dict = {"media_file": open(input_path, "rb")}
+
+            response = self.network.request(
+                {
+                    "url": "/audio-separation",
+                    "method": "POST",
+                    "headers": headers,
+                    "files": files,
+                    "use_json": False,
+                }
+            )
+
+            data = response["data"]
+            task_id = data.get("task_id")
+
+            if task_id:
+                result = self._poll_task("/audio-separation", task_id, api_key)
+                run_id = result.get("run_id")
+
+                if run_id:
+                    result_response = self.network.request(
+                        {
+                            "url": f"/audio-separation-result/{run_id}",
+                            "method": "GET",
+                            "headers": headers,
+                        }
+                    )
+                    return result_response["data"]
+
+                return result
+
+            return data
+        except Exception as e:
+            raise Exception(f"CAMB AI audio separation failed: {str(e)}")

--- a/bridges/toolkits/music_audio/toolkit.json
+++ b/bridges/toolkits/music_audio/toolkit.json
@@ -15,6 +15,7 @@
     "elevenlabs_audio",
     "ecapa",
     "chatterbox_onnx",
-    "ultimate_vocal_remover_onnx"
+    "ultimate_vocal_remover_onnx",
+    "camb_ai_audio"
   ]
 }

--- a/bridges/toolkits/music_audio/tools/camb_ai_audio.tool.json
+++ b/bridges/toolkits/music_audio/tools/camb_ai_audio.tool.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "../../../../schemas/tool-schemas/tool.json",
+  "tool_id": "camb_ai_audio",
+  "toolkit_id": "music_audio",
+  "name": "CAMB AI Audio",
+  "description": "A tool for audio processing using CAMB AI's API. Supports TTS, translation, transcription, translated TTS, voice cloning, voice listing, dubbing, text-to-sound, and audio separation.",
+  "icon_name": "sound-module",
+  "author": {
+    "name": "CAMB AI",
+    "email": "support@camb.ai",
+    "url": "https://camb.ai"
+  },
+  "functions": {
+    "textToSpeech": {
+      "description": "Convert text to speech using CAMB AI's streaming TTS API. Saves the generated audio to a file.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The text to convert to speech"
+          },
+          "outputPath": {
+            "type": "string",
+            "description": "Path to save the generated audio file"
+          },
+          "language": {
+            "type": "integer",
+            "description": "CAMB AI language ID (e.g., 1 for English)"
+          },
+          "voiceId": {
+            "type": "integer",
+            "description": "Voice ID to use for synthesis"
+          },
+          "apiKey": {
+            "type": "string"
+          },
+          "speechModel": {
+            "type": "string",
+            "description": "TTS model to use (e.g., 'mars-flash')"
+          }
+        },
+        "required": [
+          "text",
+          "outputPath",
+          "language"
+        ]
+      }
+    },
+    "translate": {
+      "description": "Translate text from one language to another using CAMB AI's translation stream API.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The text to translate"
+          },
+          "sourceLanguage": {
+            "type": "integer",
+            "description": "CAMB AI source language ID"
+          },
+          "targetLanguage": {
+            "type": "integer",
+            "description": "CAMB AI target language ID"
+          },
+          "apiKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "sourceLanguage",
+          "targetLanguage"
+        ]
+      }
+    },
+    "transcribeToFile": {
+      "description": "Transcribe audio to a file using CAMB AI's transcription API.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "inputPath": {
+            "type": "string",
+            "description": "Path to the audio file to transcribe"
+          },
+          "outputPath": {
+            "type": "string",
+            "description": "Path to save the JSON transcription"
+          },
+          "language": {
+            "type": "integer",
+            "description": "CAMB AI language ID for the audio"
+          },
+          "apiKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputPath",
+          "outputPath",
+          "language"
+        ]
+      }
+    },
+    "translatedTts": {
+      "description": "Translate text and generate speech in the target language using CAMB AI's translated TTS API.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The text to translate and speak"
+          },
+          "voiceId": {
+            "type": "integer",
+            "description": "Voice ID for the output speech"
+          },
+          "sourceLanguage": {
+            "type": "integer",
+            "description": "CAMB AI source language ID"
+          },
+          "targetLanguage": {
+            "type": "integer",
+            "description": "CAMB AI target language ID"
+          },
+          "apiKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "voiceId",
+          "sourceLanguage",
+          "targetLanguage"
+        ]
+      }
+    },
+    "cloneVoice": {
+      "description": "Clone a voice from an audio sample using CAMB AI's voice cloning API.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "inputPath": {
+            "type": "string",
+            "description": "Path to the audio sample for voice cloning"
+          },
+          "voiceName": {
+            "type": "string",
+            "description": "Name for the cloned voice"
+          },
+          "gender": {
+            "type": "integer",
+            "description": "Gender of the voice (1=male, 2=female)"
+          },
+          "apiKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputPath",
+          "voiceName",
+          "gender"
+        ]
+      }
+    },
+    "listVoices": {
+      "description": "List all available voices from CAMB AI.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "apiKey": {
+            "type": "string"
+          }
+        },
+        "required": []
+      }
+    },
+    "dubMedia": {
+      "description": "Dub a video or audio file into a target language using CAMB AI's dubbing API.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "videoUrl": {
+            "type": "string",
+            "description": "URL of the video/audio to dub"
+          },
+          "sourceLanguage": {
+            "type": "integer",
+            "description": "CAMB AI source language ID"
+          },
+          "targetLanguage": {
+            "type": "integer",
+            "description": "CAMB AI target language ID"
+          },
+          "apiKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "videoUrl",
+          "sourceLanguage",
+          "targetLanguage"
+        ]
+      }
+    },
+    "textToSound": {
+      "description": "Generate music or sound effects from a text prompt using CAMB AI's text-to-sound API.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "description": "Text description of the sound to generate"
+          },
+          "duration": {
+            "type": "number",
+            "description": "Desired duration of the audio in seconds"
+          },
+          "apiKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "prompt"
+        ]
+      }
+    },
+    "separateAudio": {
+      "description": "Separate vocals from instrumental audio using CAMB AI's audio separation API.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "inputPath": {
+            "type": "string",
+            "description": "Path to the audio file to separate"
+          },
+          "apiKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputPath"
+        ]
+      }
+    }
+  }
+}

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -331,10 +331,12 @@ export const HAS_LLM_ACTION_RECOGNITION =
 export const LEON_ROUTING_MODE = process.env['LEON_ROUTING_MODE'] || 'smart'
 export const LEON_PULSE_ENABLED = true
 export const LEON_PULSE_INTERVAL_MS = 30 * 60 * 1_000
+const NEEDS_LOCAL_STT = HAS_STT && STT_PROVIDER === 'local'
+const NEEDS_LOCAL_TTS = HAS_TTS && TTS_PROVIDER === 'local'
 export const SHOULD_START_PYTHON_TCP_SERVER = !(
   LEON_ROUTING_MODE.toLowerCase() === 'agent' &&
-  !HAS_STT &&
-  !HAS_TTS
+  !NEEDS_LOCAL_STT &&
+  !NEEDS_LOCAL_TTS
 )
 export const LEON_DISABLED_CONTEXT_FILES =
   process.env['LEON_DISABLED_CONTEXT_FILES'] || ''

--- a/server/src/core/tts/synthesizers/camb-ai-synthesizer.ts
+++ b/server/src/core/tts/synthesizers/camb-ai-synthesizer.ts
@@ -1,0 +1,126 @@
+import path from 'node:path'
+import fs from 'node:fs'
+
+import type { LongLanguageCode } from '@/types'
+import type { SynthesizeResult } from '@/core/tts/types'
+import { LANG, TMP_PATH } from '@/constants'
+import { TTS } from '@/core'
+import { TTSSynthesizerBase } from '@/core/tts/tts-synthesizer-base'
+import { LogHelper } from '@/helpers/log-helper'
+import { StringHelper } from '@/helpers/string-helper'
+
+const LANGUAGE_MAP: Record<string, string> = {
+  'en-US': 'en-us',
+  'fr-FR': 'fr-fr',
+  'es-ES': 'es-es',
+  'de-DE': 'de-de',
+  'it-IT': 'it-it',
+  'pt-BR': 'pt-br',
+  'pt-PT': 'pt-pt',
+  'ja-JP': 'ja-jp',
+  'ko-KR': 'ko-kr',
+  'zh-CN': 'zh-cn',
+  'zh-TW': 'zh-tw',
+  'ar-SA': 'ar-sa',
+  'hi-IN': 'hi-in',
+  'ru-RU': 'ru-ru',
+  'nl-NL': 'nl-nl',
+  'pl-PL': 'pl-pl',
+  'tr-TR': 'tr-tr',
+  'vi-VN': 'vi-vn',
+  'th-TH': 'th-th',
+  'sv-SE': 'sv-se'
+}
+
+export default class CambAISynthesizer extends TTSSynthesizerBase {
+  protected readonly name = 'CAMB AI Synthesizer'
+  protected readonly lang = LANG as LongLanguageCode
+  private readonly apiKey: string | undefined
+
+  constructor(lang: LongLanguageCode) {
+    super()
+
+    LogHelper.title(this.name)
+    LogHelper.success('New instance')
+
+    try {
+      this.lang = lang
+      this.apiKey = process.env['CAMB_AI_API_KEY']
+
+      if (!this.apiKey) {
+        LogHelper.error(
+          `${this.name}: CAMB_AI_API_KEY environment variable is not set`
+        )
+      }
+
+      LogHelper.success('Synthesizer initialized')
+    } catch (e) {
+      LogHelper.error(`${this.name}: ${e}`)
+    }
+  }
+
+  public async synthesize(speech: string): Promise<SynthesizeResult | null> {
+    const audioFilePath = path.join(
+      TMP_PATH,
+      `${Date.now()}-${StringHelper.random(4)}.wav`
+    )
+
+    try {
+      if (!this.apiKey) {
+        LogHelper.error(`${this.name} - CAMB_AI_API_KEY is not set`)
+        return null
+      }
+
+      const language =
+        LANGUAGE_MAP[this.lang] || this.lang.toLowerCase()
+
+      const voiceId = process.env['CAMB_AI_VOICE_ID']
+        ? Number(process.env['CAMB_AI_VOICE_ID'])
+        : 147320
+
+      const body = JSON.stringify({
+        text: speech,
+        voice_id: voiceId,
+        language,
+        speech_model: process.env['CAMB_AI_TTS_MODEL'] || 'mars-flash',
+        output_configuration: { format: 'wav' }
+      })
+
+      const response = await fetch(
+        'https://client.camb.ai/apis/tts-stream',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': this.apiKey
+          },
+          body
+        }
+      )
+
+      if (!response.ok) {
+        throw new Error(
+          `CAMB AI TTS request failed with status ${response.status}: ${response.statusText}`
+        )
+      }
+
+      const arrayBuffer = await response.arrayBuffer()
+      const buffer = Buffer.from(arrayBuffer)
+
+      await fs.promises.writeFile(audioFilePath, buffer)
+
+      const duration = await this.getAudioDuration(audioFilePath)
+
+      TTS.em.emit('saved', duration)
+
+      return {
+        audioFilePath,
+        duration
+      }
+    } catch (e) {
+      LogHelper.error(`${this.name} - Failed to synthesize speech: ${e}`)
+    }
+
+    return null
+  }
+}

--- a/server/src/core/tts/tts.ts
+++ b/server/src/core/tts/tts.ts
@@ -21,7 +21,8 @@ const PROVIDERS_MAP = {
   [TTSProviders.GoogleCloudTTS]: TTSSynthesizers.GoogleCloudTTS,
   [TTSProviders.WatsonTTS]: TTSSynthesizers.WatsonTTS,
   [TTSProviders.AmazonPolly]: TTSSynthesizers.AmazonPolly,
-  [TTSProviders.Flite]: TTSSynthesizers.Flite
+  [TTSProviders.Flite]: TTSSynthesizers.Flite,
+  [TTSProviders.CambAI]: TTSSynthesizers.CambAI
 }
 
 export default class TTS {

--- a/server/src/core/tts/types.ts
+++ b/server/src/core/tts/types.ts
@@ -3,13 +3,15 @@ import type AmazonPollySynthesizer from '@/core/tts/synthesizers/amazon-polly-sy
 import type FliteSynthesizer from '@/core/tts/synthesizers/flite-synthesizer'
 import type GoogleCloudTTSSynthesizer from '@/core/tts/synthesizers/google-cloud-tts-synthesizer'
 import type WatsonTTSSynthesizer from '@/core/tts/synthesizers/watson-tts-synthesizer'
+import type CambAISynthesizer from '@/core/tts/synthesizers/camb-ai-synthesizer'
 
 export enum TTSProviders {
   Local = 'local',
   AmazonPolly = 'amazon-polly',
   GoogleCloudTTS = 'google-cloud-tts',
   WatsonTTS = 'watson-tts',
-  Flite = 'flite'
+  Flite = 'flite',
+  CambAI = 'camb-ai'
 }
 
 export enum TTSSynthesizers {
@@ -17,7 +19,8 @@ export enum TTSSynthesizers {
   AmazonPolly = 'amazon-polly-synthesizer',
   GoogleCloudTTS = 'google-cloud-tts-synthesizer',
   WatsonTTS = 'watson-tts-synthesizer',
-  Flite = 'flite-synthesizer'
+  Flite = 'flite-synthesizer',
+  CambAI = 'camb-ai-synthesizer'
 }
 
 export interface SynthesizeResult {
@@ -31,4 +34,5 @@ export type TTSSynthesizer =
   | FliteSynthesizer
   | GoogleCloudTTSSynthesizer
   | WatsonTTSSynthesizer
+  | CambAISynthesizer
   | undefined

--- a/test_camb_ai_leon.py
+++ b/test_camb_ai_leon.py
@@ -1,0 +1,365 @@
+"""All-encompassing test for the CAMB AI Leon integration.
+
+Tests every API endpoint used by the toolkit tool and core TTS provider
+against the real CAMB AI API, using raw HTTP requests (no Leon dependencies).
+
+Usage:
+    export CAMB_API_KEY="your-key"
+    export CAMB_AUDIO_SAMPLE="path/to/audio.wav"
+    python test_camb_ai_leon.py
+"""
+
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent / ".env")
+
+import requests
+
+CAMB_API_BASE = "https://client.camb.ai/apis"
+
+API_KEY = os.environ.get("CAMB_API_KEY")
+if not API_KEY:
+    raise RuntimeError("Set CAMB_API_KEY environment variable to run tests")
+
+AUDIO_SAMPLE = os.environ.get(
+    "CAMB_AUDIO_SAMPLE",
+    str(Path(__file__).resolve().parent.parent / "yt-dlp/voices/original/sabrina-original-clip.mp3"),
+)
+if AUDIO_SAMPLE and not os.path.isabs(AUDIO_SAMPLE):
+    AUDIO_SAMPLE = str(Path(__file__).resolve().parent / AUDIO_SAMPLE)
+if not AUDIO_SAMPLE or not os.path.isfile(AUDIO_SAMPLE):
+    raise RuntimeError(
+        "Set CAMB_AUDIO_SAMPLE environment variable to a local audio file path"
+    )
+
+HEADERS = {"x-api-key": API_KEY, "Content-Type": "application/json"}
+HEADERS_KEY_ONLY = {"x-api-key": API_KEY}
+
+MAX_POLL_ATTEMPTS = 120
+POLL_INTERVAL = 3
+
+
+def play(path: str):
+    """Play an audio file with afplay (macOS)."""
+    if sys.platform == "darwin":
+        print(f"  Playing: {path}")
+        subprocess.run(["afplay", path], check=False)
+    else:
+        print(f"  Audio file at: {path} (afplay not available on this platform)")
+
+
+def poll_task(endpoint: str, task_id: int) -> int:
+    """Poll a task endpoint until completion. Returns run_id."""
+    for _ in range(MAX_POLL_ATTEMPTS):
+        resp = requests.get(
+            f"{CAMB_API_BASE}/{endpoint}/{task_id}",
+            headers=HEADERS,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        status = data.get("status", "").upper()
+        if status in ("SUCCESS", "COMPLETED"):
+            run_id = data.get("run_id")
+            if run_id is None:
+                raise RuntimeError(f"Task completed but no run_id: {data}")
+            return run_id
+        if status in ("FAILED", "ERROR"):
+            raise RuntimeError(f"Task failed: {data.get('error', data)}")
+        time.sleep(POLL_INTERVAL)
+    raise RuntimeError(f"Task timed out after {MAX_POLL_ATTEMPTS * POLL_INTERVAL}s")
+
+
+# ---------------------------------------------------------------------------
+# 1. List Voices  (GET /list-voices)
+# ---------------------------------------------------------------------------
+def test_list_voices():
+    """1. Voice List: list available voices via /list-voices."""
+    resp = requests.get(
+        f"{CAMB_API_BASE}/list-voices",
+        headers=HEADERS,
+        timeout=30,
+    )
+    resp.raise_for_status()
+    voices = resp.json()
+    assert isinstance(voices, list), f"Expected list, got {type(voices)}"
+    assert len(voices) > 0, "No voices returned"
+    print(f"  Got {len(voices)} voices")
+    first = voices[0]
+    print(f"  First voice: id={first.get('id')}, name={first.get('voice_name')}")
+
+
+# ---------------------------------------------------------------------------
+# 2. TTS Streaming  (POST /tts-stream)
+# ---------------------------------------------------------------------------
+def test_tts():
+    """2. Text-to-Speech: stream audio via /tts-stream."""
+    resp = requests.post(
+        f"{CAMB_API_BASE}/tts-stream",
+        headers=HEADERS,
+        json={
+            "text": "Hello from CAMB AI and the Leon integration! This is a text to speech test.",
+            "voice_id": 147320,
+            "language": "en-us",
+            "speech_model": "mars-flash",
+            "output_configuration": {"format": "wav"},
+        },
+        stream=True,
+        timeout=120,
+    )
+    resp.raise_for_status()
+    chunks = []
+    for chunk in resp.iter_content(chunk_size=4096):
+        if chunk:
+            chunks.append(chunk)
+    audio_data = b"".join(chunks)
+    assert len(audio_data) > 0, "No audio data received"
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+        f.write(audio_data)
+        path = f.name
+    print(f"  Audio saved to: {path} ({len(audio_data)} bytes)")
+    play(path)
+
+
+# ---------------------------------------------------------------------------
+# 3. Translation  (POST /translate, GET /translation-result/{run_id})
+# ---------------------------------------------------------------------------
+def test_translation():
+    """3. Translation: translate text via /translate."""
+    resp = requests.post(
+        f"{CAMB_API_BASE}/translate",
+        headers=HEADERS,
+        json={
+            "texts": ["Hello, how are you?"],
+            "source_language": 1,
+            "target_language": 2,
+        },
+        timeout=60,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    task_id = data.get("task_id")
+    assert task_id is not None, f"No task_id: {data}"
+    print(f"  task_id: {task_id}")
+
+    run_id = poll_task("translate", task_id)
+    print(f"  run_id: {run_id}")
+
+    result_resp = requests.get(
+        f"{CAMB_API_BASE}/translation-result/{run_id}",
+        headers=HEADERS,
+        timeout=30,
+    )
+    result_resp.raise_for_status()
+    result = result_resp.json()
+    print(f"  Result: {result}")
+
+
+# ---------------------------------------------------------------------------
+# 4. Transcription  (POST /transcribe, GET /transcription-result/{run_id})
+# ---------------------------------------------------------------------------
+def test_transcription():
+    """4. Transcription: transcribe audio via /transcribe."""
+    filename = os.path.basename(AUDIO_SAMPLE)
+    with open(AUDIO_SAMPLE, "rb") as f:
+        resp = requests.post(
+            f"{CAMB_API_BASE}/transcribe",
+            headers=HEADERS_KEY_ONLY,
+            files={"media_file": (filename, f, "audio/mpeg")},
+            data={"language": 1},
+            timeout=60,
+        )
+    resp.raise_for_status()
+    data = resp.json()
+    task_id = data.get("task_id")
+    assert task_id is not None, f"No task_id: {data}"
+    print(f"  task_id: {task_id}")
+
+    run_id = poll_task("transcribe", task_id)
+    print(f"  run_id: {run_id}")
+
+    result_resp = requests.get(
+        f"{CAMB_API_BASE}/transcription-result/{run_id}",
+        headers=HEADERS,
+        timeout=30,
+    )
+    result_resp.raise_for_status()
+    result = result_resp.json()
+    text = result.get("transcript") or result.get("text") or str(result)
+    print(f"  Transcription: {str(text)[:300]}")
+
+
+# ---------------------------------------------------------------------------
+# 5. Translated TTS  (POST /translated-tts, poll, GET /tts-result/{run_id})
+# ---------------------------------------------------------------------------
+def test_translated_tts():
+    """5. Translated TTS: translate + speak via /translated-tts."""
+    resp = requests.post(
+        f"{CAMB_API_BASE}/translated-tts",
+        headers=HEADERS,
+        json={
+            "text": "Hello, how are you?",
+            "source_language": 1,
+            "target_language": 2,
+            "voice_id": 147320,
+        },
+        timeout=60,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    task_id = data.get("task_id")
+    assert task_id is not None, f"No task_id: {data}"
+    print(f"  task_id: {task_id}")
+
+    run_id = poll_task("translated-tts", task_id)
+    print(f"  run_id: {run_id}")
+
+    audio_resp = requests.get(
+        f"{CAMB_API_BASE}/tts-result/{run_id}",
+        headers=HEADERS_KEY_ONLY,
+        timeout=120,
+    )
+    audio_resp.raise_for_status()
+    audio_data = audio_resp.content
+    assert len(audio_data) > 0, "No audio data"
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+        f.write(audio_data)
+        path = f.name
+    print(f"  Audio saved to: {path} ({len(audio_data)} bytes)")
+    play(path)
+
+
+# ---------------------------------------------------------------------------
+# 6. Text-to-Sound  (POST /text-to-sound, GET /text-to-sound-result/{run_id})
+# ---------------------------------------------------------------------------
+def test_text_to_sound():
+    """6. Text-to-Sound: generate audio from description via /text-to-sound."""
+    resp = requests.post(
+        f"{CAMB_API_BASE}/text-to-sound",
+        headers=HEADERS,
+        json={"prompt": "gentle rain on a rooftop"},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    task_id = data.get("task_id")
+    assert task_id is not None, f"No task_id: {data}"
+    print(f"  task_id: {task_id}")
+
+    run_id = poll_task("text-to-sound", task_id)
+    print(f"  run_id: {run_id}")
+
+    audio_resp = requests.get(
+        f"{CAMB_API_BASE}/text-to-sound-result/{run_id}",
+        headers=HEADERS_KEY_ONLY,
+        timeout=120,
+    )
+    audio_resp.raise_for_status()
+    audio_data = audio_resp.content
+    assert len(audio_data) > 0, "No audio data"
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+        f.write(audio_data)
+        path = f.name
+    print(f"  Audio saved to: {path} ({len(audio_data)} bytes)")
+    play(path)
+
+
+# ---------------------------------------------------------------------------
+# 7. Voice Clone  (POST /create-custom-voice)
+# ---------------------------------------------------------------------------
+def test_voice_clone():
+    """7. Voice Clone: clone a voice via /create-custom-voice."""
+    filename = os.path.basename(AUDIO_SAMPLE)
+    with open(AUDIO_SAMPLE, "rb") as f:
+        audio_data = f.read()
+
+    resp = requests.post(
+        f"{CAMB_API_BASE}/create-custom-voice",
+        headers=HEADERS_KEY_ONLY,
+        files={"file": (filename, io.BytesIO(audio_data), "audio/mpeg")},
+        data={"voice_name": "leon_test_voice", "gender": 2},
+        timeout=120,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    voice_id = data.get("voice_id") or data.get("id")
+    print(f"  Cloned voice_id: {voice_id}")
+    print(f"  Full response: {data}")
+    assert voice_id is not None, f"No voice_id in response: {data}"
+
+
+# ---------------------------------------------------------------------------
+# 8. Audio Separation  (POST /audio-separation, GET /audio-separation-result/{run_id})
+# ---------------------------------------------------------------------------
+def test_audio_separation():
+    """8. Audio Separation: separate vocals from background via /audio-separation."""
+    filename = os.path.basename(AUDIO_SAMPLE)
+    with open(AUDIO_SAMPLE, "rb") as f:
+        audio_data = f.read()
+
+    resp = requests.post(
+        f"{CAMB_API_BASE}/audio-separation",
+        headers=HEADERS_KEY_ONLY,
+        files={"media_file": (filename, io.BytesIO(audio_data), "audio/mpeg")},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    task_id = data.get("task_id")
+    assert task_id is not None, f"No task_id: {data}"
+    print(f"  task_id: {task_id}")
+
+    run_id = poll_task("audio-separation", task_id)
+    print(f"  run_id: {run_id}")
+
+    result_resp = requests.get(
+        f"{CAMB_API_BASE}/audio-separation-result/{run_id}",
+        headers=HEADERS,
+        timeout=30,
+    )
+    result_resp.raise_for_status()
+    result = result_resp.json()
+    fg = result.get("foreground_audio_url")
+    bg = result.get("background_audio_url")
+    print(f"  Foreground: {fg}")
+    print(f"  Background: {bg}")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    tests = [
+        test_list_voices,
+        test_tts,
+        test_translation,
+        test_transcription,
+        test_translated_tts,
+        test_text_to_sound,
+        test_voice_clone,
+        test_audio_separation,
+    ]
+    passed = 0
+    failed = 0
+    for t in tests:
+        print(f"\n--- {t.__doc__} ---")
+        try:
+            t()
+            print("  PASSED")
+            passed += 1
+        except Exception as e:
+            print(f"  FAILED: {e}")
+            failed += 1
+
+    print(f"\n{'=' * 60}")
+    print(f"Results: {passed} passed, {failed} failed, {passed + failed} total")
+    print(f"{'=' * 60}")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

- Adds a new **CAMB AI audio toolkit tool** (`camb_ai_audio`) to the `music_audio` toolkit, exposing TTS, transcription, translation, translated TTS, voice cloning, text-to-sound, audio separation, and dubbing capabilities via the CAMB AI API
- Adds a **CAMB AI core TTS synthesizer** (`camb-ai-synthesizer.ts`) so Leon can use CAMB AI as its native text-to-speech provider (`LEON_TTS_PROVIDER=camb-ai`)
- Updates `SHOULD_START_PYTHON_TCP_SERVER` to only require the Python TCP server when using local STT/TTS providers, allowing external providers like CAMB AI to work without it
- Includes an integration test (`test_camb_ai_leon.py`) that validates all 8 CAMB AI API endpoints