### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,7 +15,7 @@ LEON_DISABLED_CONTEXT_FILES=
 
 # LLM configuration
 
-# Providers: llamacpp | sglang | openrouter | openai | zai | moonshotai | anthropic | huggingface | cerebras | groq
+# Providers: llamacpp | sglang | openrouter | openai | zai | moonshotai | anthropic | huggingface | cerebras | groq | astraflow
 # Keep empty to default to the installed local LLM
 # Set to "none" to disable AI until you configure a provider later
 LEON_LLM=none
@@ -60,6 +60,9 @@ LEON_CEREBRAS_API_KEY=
 
 # Groq API key
 LEON_GROQ_API_KEY=
+
+# Astraflow API key (global endpoint — https://astraflow.ucloud-global.com)
+LEON_ASTRAFLOW_API_KEY=
 
 # Enable/disable Leon's wake word
 LEON_WAKE_WORD=false

--- a/server/src/core/llm-manager/llm-provider-account-configs.ts
+++ b/server/src/core/llm-manager/llm-provider-account-configs.ts
@@ -61,6 +61,12 @@ export const LLM_PROVIDER_ACCOUNT_CONFIGS: ReadonlyArray<LLMProviderAccountConfi
       value: LLMProviders.HuggingFace,
       apiKeyEnv: 'LEON_HUGGINGFACE_API_KEY',
       apiKeyURL: 'https://huggingface.co/settings/tokens'
+    },
+    {
+      label: 'Astraflow',
+      value: LLMProviders.Astraflow,
+      apiKeyEnv: 'LEON_ASTRAFLOW_API_KEY',
+      apiKeyURL: 'https://astraflow.ucloud-global.com'
     }
   ])
 

--- a/server/src/core/llm-manager/llm-provider.ts
+++ b/server/src/core/llm-manager/llm-provider.ts
@@ -83,7 +83,8 @@ const LLM_PROVIDERS_MAP = {
   [LLMProviders.Anthropic]: 'anthropic-llm-provider',
   [LLMProviders.MoonshotAI]: 'moonshotai-llm-provider',
   [LLMProviders.Cerebras]: 'cerebras-llm-provider',
-  [LLMProviders.HuggingFace]: 'huggingface-llm-provider'
+  [LLMProviders.HuggingFace]: 'huggingface-llm-provider',
+  [LLMProviders.Astraflow]: 'astraflow-llm-provider'
 }
 const DEFAULT_MAX_EXECUTION_RETRIES = 2
 const DEFAULT_REMOTE_PROVIDER_ERROR_RETRIES = 1

--- a/server/src/core/llm-manager/llm-providers/astraflow-llm-provider.ts
+++ b/server/src/core/llm-manager/llm-providers/astraflow-llm-provider.ts
@@ -1,0 +1,18 @@
+import AISDKRemoteLLMProvider from '@/core/llm-manager/llm-providers/ai-sdk-remote-llm-provider'
+import type { ResolvedLLMTarget } from '@/core/llm-manager/llm-routing'
+
+/**
+ * @see https://astraflow.ucloud-global.com
+ */
+export default class AstraflowLLMProvider extends AISDKRemoteLLMProvider {
+  constructor(target: ResolvedLLMTarget) {
+    super({
+      name: 'Astraflow LLM Provider',
+      providerName: 'astraflow',
+      apiKeyEnv: 'LEON_ASTRAFLOW_API_KEY',
+      model: target.model,
+      baseURL: 'https://api-us-ca.umodelverse.ai/v1',
+      flavor: 'openai-compatible'
+    })
+  }
+}

--- a/server/src/core/llm-manager/types.ts
+++ b/server/src/core/llm-manager/types.ts
@@ -35,7 +35,8 @@ export enum LLMProviders {
   Anthropic = 'anthropic',
   MoonshotAI = 'moonshotai',
   Cerebras = 'cerebras',
-  HuggingFace = 'huggingface'
+  HuggingFace = 'huggingface',
+  Astraflow = 'astraflow'
 }
 
 export enum ActionCallingStatus {


### PR DESCRIPTION
### What type of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?

- [ ] Yes
- [x] No

### List any relevant issue numbers:

### Description:

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider. Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models.

- **Global endpoint**: `https://api-us-ca.umodelverse.ai/v1`
- **Website**: https://astraflow.ucloud-global.com
- **API key signup**: https://astraflow.ucloud-global.com

**Changes:**

| File | Change |
|------|--------|
| `server/src/core/llm-manager/types.ts` | Added `Astraflow = 'astraflow'` to `LLMProviders` enum |
| `server/src/core/llm-manager/llm-provider.ts` | Registered `astraflow-llm-provider` in `LLM_PROVIDERS_MAP` |
| `server/src/core/llm-manager/llm-providers/astraflow-llm-provider.ts` | New provider file using `AISDKRemoteLLMProvider` with `flavor: 'openai-compatible'` |
| `server/src/core/llm-manager/llm-provider-account-configs.ts` | Added Astraflow account config with `LEON_ASTRAFLOW_API_KEY` |
| `.env.sample` | Listed `astraflow` in providers comment; added `LEON_ASTRAFLOW_API_KEY` variable |

**Usage:**

```env
LEON_ASTRAFLOW_API_KEY=your_api_key_here
```

```env
LEON_LLM=astraflow/your-model-name
```

The integration follows the same pattern as Z.AI and other OpenAI-compatible providers, using `flavor: 'openai-compatible'` in the `AISDKRemoteLLMProvider` base class.