### PR TITLE
fix(provider/minimax): support configurable endpoints

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -46,6 +46,11 @@ llm:
         # The value is read from LEON_ZAI_API_KEY in your profile .env file.
         env: LEON_ZAI_API_KEY
     minimax:
+      # Global OpenAI-compatible: https://api.minimax.io/v1
+      # China OpenAI-compatible: https://api.minimaxi.com/v1
+      # Global Anthropic-compatible: https://api.minimax.io/anthropic
+      # China Anthropic-compatible: https://api.minimaxi.com/anthropic
+      base_url: https://api.minimax.io/v1
       api_key:
         # The value is read from LEON_MINIMAX_API_KEY in your profile .env file.
         env: LEON_MINIMAX_API_KEY

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -110,6 +110,7 @@ const DEFAULT_CONFIG: LeonConfig = {
         }
       },
       minimax: {
+        base_url: 'https://api.minimax.io/v1',
         api_key: {
           env: 'LEON_MINIMAX_API_KEY'
         }

--- a/server/src/core/llm-manager/llm-providers/minimax-llm-provider.ts
+++ b/server/src/core/llm-manager/llm-providers/minimax-llm-provider.ts
@@ -4,11 +4,39 @@ import type {
   CompletionParams,
   LLMReasoningMode
 } from '@/core/llm-manager/types'
+import { CONFIG_MANAGER } from '@/config'
 
 const ADAPTIVE_THINKING_MODEL = 'MiniMax-M3'
+const DEFAULT_BASE_URL = 'https://api.minimax.io/v1'
+
+type MiniMaxFlavor = 'anthropic' | 'openai-compatible'
+
+interface MiniMaxEndpoint {
+  baseURL: string
+  flavor: MiniMaxFlavor
+}
+
+function resolveMiniMaxEndpoint(): MiniMaxEndpoint {
+  const configuredBaseURL =
+    CONFIG_MANAGER.getProviderBaseURL('minimax') || DEFAULT_BASE_URL
+  const publicBaseURL = configuredBaseURL.replace(/\/+$/, '')
+
+  if (publicBaseURL.endsWith('/anthropic')) {
+    return {
+      baseURL: `${publicBaseURL}/v1`,
+      flavor: 'anthropic'
+    }
+  }
+
+  return {
+    baseURL: publicBaseURL,
+    flavor: 'openai-compatible'
+  }
+}
 
 function buildMiniMaxProviderOptions(
   model: string,
+  flavor: MiniMaxFlavor,
   completionParams: CompletionParams,
   reasoningMode: LLMReasoningMode | null
 ): Record<string, unknown> {
@@ -17,16 +45,27 @@ function buildMiniMaxProviderOptions(
     reasoningMode === 'off' ||
     reasoningMode === 'guarded'
 
+  const thinking = model === ADAPTIVE_THINKING_MODEL
+    ? {
+        thinking: {
+          type: disableThinking ? 'disabled' : 'adaptive'
+        }
+      }
+    : {}
+
+  if (flavor === 'anthropic') {
+    return {
+      anthropic: {
+        ...thinking,
+        sendReasoning: true
+      }
+    }
+  }
+
   return {
     minimax: {
       reasoning_split: true,
-      ...(model === ADAPTIVE_THINKING_MODEL
-        ? {
-            thinking: {
-              type: disableThinking ? 'disabled' : 'adaptive'
-            }
-          }
-        : {})
+      ...thinking
     }
   }
 }
@@ -36,16 +75,19 @@ function buildMiniMaxProviderOptions(
  */
 export default class MiniMaxLLMProvider extends AISDKRemoteLLMProvider {
   constructor(target: ResolvedLLMTarget) {
+    const endpoint = resolveMiniMaxEndpoint()
+
     super({
       name: 'MiniMax LLM Provider',
       providerName: 'minimax',
       apiKeyEnv: 'LEON_MINIMAX_API_KEY',
       model: target.model,
-      baseURL: 'https://api.minimax.io/v1',
-      flavor: 'openai-compatible',
+      baseURL: endpoint.baseURL,
+      flavor: endpoint.flavor,
       buildProviderOptions: ({ completionParams, reasoningMode }) =>
         buildMiniMaxProviderOptions(
           target.model,
+          endpoint.flavor,
           completionParams,
           reasoningMode
         )

--- a/server/src/schemas/core-schemas.ts
+++ b/server/src/schemas/core-schemas.ts
@@ -74,7 +74,7 @@ export const configSchemaObject = strictObject({
       sglang: llmProviderWithBaseURL,
       openrouter: llmProvider,
       zai: llmProvider,
-      minimax: llmProvider,
+      minimax: llmProviderWithBaseURL,
       openai: llmProvider,
       anthropic: llmProvider,
       moonshotai: llmProvider,

--- a/test/agent/unit/minimax-llm-provider.spec.ts
+++ b/test/agent/unit/minimax-llm-provider.spec.ts
@@ -7,7 +7,10 @@ import { LLMDuties, LLMProviders } from '@/core/llm-manager/types'
 
 vi.mock('@/config', () => ({
   CONFIG_MANAGER: {
-    getProviderAPIKeyEnv: vi.fn(() => null)
+    getProviderAPIKeyEnv: vi.fn(() => null),
+    getProviderBaseURL: vi.fn(
+      () => process.env['TEST_MINIMAX_BASE_URL'] || ''
+    )
   }
 }))
 
@@ -57,9 +60,11 @@ function createCompletionParams(
 describe('MiniMaxLLMProvider', () => {
   beforeEach(() => {
     vi.stubEnv('LEON_MINIMAX_API_KEY', 'test-minimax-key')
+    vi.stubEnv('TEST_MINIMAX_BASE_URL', '')
   })
 
   afterEach(() => {
+    vi.unstubAllEnvs()
     vi.unstubAllGlobals()
   })
 
@@ -107,33 +112,97 @@ describe('MiniMaxLLMProvider', () => {
     })
   })
 
-  it('sends the documented request fields to the OpenAI-compatible endpoint', async () => {
+  it('keeps MiniMax-M2.7 thinking enabled with Anthropic compatibility', () => {
+    vi.stubEnv(
+      'TEST_MINIMAX_BASE_URL',
+      'https://api.minimax.io/anthropic'
+    )
+    const provider = createProvider('MiniMax-M2.7')
+    const options = provider.buildCallOptions(
+      'Answer directly.',
+      createCompletionParams({ reasoningMode: 'off' })
+    )
+
+    expect(options['providerOptions']).toEqual({
+      anthropic: {
+        sendReasoning: true
+      }
+    })
+  })
+
+  it.each([
+    {
+      name: 'global OpenAI-compatible',
+      baseURL: 'https://api.minimax.io/v1',
+      expectedRequestURL: 'https://api.minimax.io/v1/chat/completions',
+      flavor: 'openai-compatible'
+    },
+    {
+      name: 'China OpenAI-compatible',
+      baseURL: 'https://api.minimaxi.com/v1',
+      expectedRequestURL: 'https://api.minimaxi.com/v1/chat/completions',
+      flavor: 'openai-compatible'
+    },
+    {
+      name: 'global Anthropic-compatible',
+      baseURL: 'https://api.minimax.io/anthropic',
+      expectedRequestURL: 'https://api.minimax.io/anthropic/v1/messages',
+      flavor: 'anthropic'
+    },
+    {
+      name: 'China Anthropic-compatible',
+      baseURL: 'https://api.minimaxi.com/anthropic',
+      expectedRequestURL: 'https://api.minimaxi.com/anthropic/v1/messages',
+      flavor: 'anthropic'
+    }
+  ])('sends a valid request to the $name endpoint', async ({
+    baseURL,
+    expectedRequestURL,
+    flavor
+  }) => {
+    vi.stubEnv('TEST_MINIMAX_BASE_URL', baseURL)
     const fetchMock = vi.fn(
       async (input: string | URL | Request, init?: RequestInit) => {
         void input
         void init
 
         return new Response(
-          JSON.stringify({
-            id: 'chatcmpl-test',
-            created: 0,
-            model: 'MiniMax-M3',
-            choices: [
-              {
-                index: 0,
-                message: {
+          JSON.stringify(
+            flavor === 'anthropic'
+              ? {
+                  id: 'msg-test',
+                  type: 'message',
                   role: 'assistant',
-                  content: 'Done.'
-                },
-                finish_reason: 'stop'
-              }
-            ],
-            usage: {
-              prompt_tokens: 1,
-              completion_tokens: 1,
-              total_tokens: 2
-            }
-          }),
+                  model: 'MiniMax-M3',
+                  content: [{ type: 'text', text: 'Done.' }],
+                  stop_reason: 'end_turn',
+                  stop_sequence: null,
+                  usage: {
+                    input_tokens: 1,
+                    output_tokens: 1
+                  }
+                }
+              : {
+                  id: 'chatcmpl-test',
+                  created: 0,
+                  model: 'MiniMax-M3',
+                  choices: [
+                    {
+                      index: 0,
+                      message: {
+                        role: 'assistant',
+                        content: 'Done.'
+                      },
+                      finish_reason: 'stop'
+                    }
+                  ],
+                  usage: {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2
+                  }
+                }
+          ),
           {
             status: 200,
             headers: { 'Content-Type': 'application/json' }
@@ -146,7 +215,9 @@ describe('MiniMaxLLMProvider', () => {
 
     await provider.runChatCompletion(
       'Answer directly.',
-      createCompletionParams({ reasoningMode: 'off' })
+      createCompletionParams({
+        reasoningMode: flavor === 'anthropic' ? 'on' : 'off'
+      })
     )
 
     const [requestURL, requestInit] = fetchMock.mock.calls[0]!
@@ -155,11 +226,13 @@ describe('MiniMaxLLMProvider', () => {
       unknown
     >
 
-    expect(String(requestURL)).toBe(
-      'https://api.minimax.io/v1/chat/completions'
+    expect(String(requestURL)).toBe(expectedRequestURL)
+    expect(requestBody['thinking']).toEqual({
+      type: flavor === 'anthropic' ? 'adaptive' : 'disabled'
+    })
+    expect(requestBody['reasoning_split']).toBe(
+      flavor === 'openai-compatible' ? true : undefined
     )
-    expect(requestBody['thinking']).toEqual({ type: 'disabled' })
-    expect(requestBody['reasoning_split']).toBe(true)
     expect(requestBody['reasoning_effort']).toBeUndefined()
   })
 })

--- a/test/controlled/unit/config.spec.ts
+++ b/test/controlled/unit/config.spec.ts
@@ -137,6 +137,7 @@ describe('ConfigManager', () => {
             }
           },
           minimax: {
+            base_url: 'https://api.minimaxi.com/anthropic',
             api_key: {
               env: 'LEON_MINIMAX_API_KEY'
             }
@@ -237,6 +238,9 @@ describe('ConfigManager', () => {
     expect(configManager.getProviderAPIKey('openai')).toBe('openai-secret')
     expect(configManager.getProviderBaseURL('llamacpp')).toBe(
       'http://127.0.0.1:8081/v1'
+    )
+    expect(configManager.getProviderBaseURL('minimax')).toBe(
+      'https://api.minimaxi.com/anthropic'
     )
   })
 })


### PR DESCRIPTION
### What type of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?

- [ ] Yes
- [x] No

### List any relevant issue numbers:

Follow-up to #579.

### Description:

- Make the MiniMax Base URL configurable through the existing provider configuration.
- Select the OpenAI-compatible or Anthropic-compatible adapter from the configured official Base URL.
- Keep Anthropic-compatible Base URLs ending in `/anthropic` and derive the SDK request path internally.
- Document the global and China endpoint options.
- Cover all four endpoint request URLs and both configured models.

### Checks:

- `pnpm run test:agent:unit` (54 passed)
- `pnpm run test:controlled:unit` (19 passed)
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint server/src/config.ts server/src/schemas/core-schemas.ts server/src/core/llm-manager/llm-providers/minimax-llm-provider.ts test/agent/unit/minimax-llm-provider.spec.ts test/controlled/unit/config.spec.ts`
- `git diff --check`
